### PR TITLE
Enforce output language independent of context

### DIFF
--- a/langchain_service/chain/qa_chain.py
+++ b/langchain_service/chain/qa_chain.py
@@ -165,6 +165,7 @@ def make_qa_chain(
         + "- Do not output JSON-only. Respond in normal sentences with lists.\n"
         + "- Ground your answer strictly in the provided context.\n"
         + "- Respond in the same language as the question (Korean/English/Chinese/Japanese).\n"
+        + "- Do not switch output language based on the context language; follow the user's question language only.\n"
         + "- If the context is insufficient, do not end with 'no information'; switch to a clarifying question.\n"
         + "- If force_clarify is True, output only a clarifying question instead of an answer.\n"
         + "- Use only the URLs in the [SOURCES] section for download/external links.\n"

--- a/langchain_service/prompt/style.py
+++ b/langchain_service/prompt/style.py
@@ -40,8 +40,9 @@ def build_system_prompt(style: Style, **flags) -> str:
     1) If the user asks in English, respond only in English. Do not mix in Korean.
     2) If the user asks in Korean, respond only in Korean (use polite honorifics). Do not mix in English.
     3) If the question is mixed-language, use the language of the last sentence as the output language.
-    4) Even if sources are in a different language, write the final response body in the output language.
+    4) Even if sources or retrieved context are in a different language, write the final response body in the output language.
        - Quotes or verbatim excerpts may remain in the original language, but your explanation must use the output language.
+    5) Never let the context language override the user's requested output language. Follow the user's question language only.
 
     [Prohibited]
     - Translating an English question into Korean or explaining in Korean.


### PR DESCRIPTION
### Motivation
- Ensure the final response language follows the user's question regardless of the language of retrieved sources or context by making the system prompt and QA chain instructions explicit.

### Description
- Add a rule to `build_system_prompt` in `langchain_service/prompt/style.py` and add an explicit instruction in `make_qa_chain` in `langchain_service/chain/qa_chain.py` to never let context language override the user's requested output language.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c6b7adf988324b7c5ae932b5b39eb)