### PR TITLE
Translate QA answers into the user's question language

### DIFF
--- a/langchain_service/llm/translator.py
+++ b/langchain_service/llm/translator.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+
+LANGUAGE_LABELS: dict[str, str] = {
+    "ko": "Korean",
+    "en": "English",
+    "ja": "Japanese",
+    "zh": "Chinese",
+}
+
+_KOREAN_RE = re.compile(r"[가-힣]")
+_JAPANESE_RE = re.compile(r"[\u3040-\u30ff]")
+_CHINESE_RE = re.compile(r"[\u4e00-\u9fff]")
+
+
+def _last_sentence(text: str) -> str:
+    raw = (text or "").strip()
+    if not raw:
+        return ""
+    parts = re.split(r"[.!?\n。！？]", raw)
+    for part in reversed(parts):
+        p = part.strip()
+        if p:
+            return p
+    return raw
+
+
+def detect_language(text: str) -> str:
+    segment = _last_sentence(text)
+    if _KOREAN_RE.search(segment):
+        return "ko"
+    if _JAPANESE_RE.search(segment):
+        return "ja"
+    if _CHINESE_RE.search(segment):
+        return "zh"
+    return "en"
+
+
+def needs_translation(text: str, target_lang: str) -> bool:
+    return detect_language(text) != target_lang
+
+
+def language_label(lang: str) -> str:
+    return LANGUAGE_LABELS.get(lang, "English")

--- a/langchain_service/prompt/style.py
+++ b/langchain_service/prompt/style.py
@@ -40,8 +40,9 @@ def build_system_prompt(style: Style, **flags) -> str:
     1) If the user asks in English, respond only in English. Do not mix in Korean.
     2) If the user asks in Korean, respond only in Korean (use polite honorifics). Do not mix in English.
     3) If the question is mixed-language, use the language of the last sentence as the output language.
-    4) Even if sources are in a different language, write the final response body in the output language.
+    4) Even if sources or retrieved context are in a different language, write the final response body in the output language.
        - Quotes or verbatim excerpts may remain in the original language, but your explanation must use the output language.
+    5) Never let the context language override the user's requested output language. Follow the user's question language only.
 
     [Prohibited]
     - Translating an English question into Korean or explaining in Korean.


### PR DESCRIPTION
### Motivation
- Ensure the final answer follows the language the user asked in, even when retrieved context or sources are in another language.
- Avoid context-driven language switching by detecting the question language and translating generated answers when needed.

### Description
- Add a new helper module `langchain_service/llm/translator.py` that detects the language of the last sentence and exposes `detect_language`, `needs_translation`, and `language_label` utilities.
- Split the QA runnable into an `answer_chain` and a post-processing translation step that uses a dedicated translation prompt and LLM to translate outputs when `needs_translation` is true.
- Wire the translation step into the chain by returning a `RunnableMap` of the answer and question followed by a `RunnableLambda` (`_translate_if_needed`) that invokes the translation chain with `target_language` when required.
- Configure the translator LLM with deterministic settings (`temperature=0.0`, `streaming=False`) and a prompt that preserves URLs, product names, Markdown, and list structure.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c6b7adf988324b7c5ae932b5b39eb)