### PR TITLE
Enforce English-only QA prompts; add HTML-comment metadata parsing and retrieval scoring

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -116,6 +116,7 @@ EMBEDDING_DIM = 1536
 VECTOR_DISTANCE_THRESHOLD = 0.35
 VECTOR_CANDIDATE_MULT = 5
 IVFFLAT_PROBES = 10   # lists=100이면 보통 5~20 사이에서 튜닝
+RAG_MIN_SCORE = float(os.getenv("RAG_MIN_SCORE", "0.12"))
 
 
 # 8) 모델 카탈로그
@@ -172,4 +173,3 @@ DEFAULT_STT_MODEL = "CLOVA_STT"
 CLOVA_STT_BILLING_UNIT_SECONDS = 6   # 6초 단위 과금
 CLOVA_STT_PRICE_PER_UNIT_KRW = 1.6      # 15초당 4원
 FX_KRW_PER_USD = 1400                 # 원→달러 환산. 미사용 시 None
-

--- a/langchain_service/chain/qa_chain.py
+++ b/langchain_service/chain/qa_chain.py
@@ -161,14 +161,19 @@ def make_qa_chain(
     system_txt = (
         system_txt
         + "\n\nAdditional instructions:\n"
-        + "- Write answers in Markdown. (You may use **bold**, lists (-), and numbered lists (1.).)\n"
-        + "- Never use code blocks. (No ``` or ```json under any circumstance.)\n"
-        + "- Do not output JSON-only. Respond in normal sentences with lists.\n"
+        + "- Always respond in Markdown (no code fences).\n"
+        + "- Append a final HTML comment block with metadata in this format:\n"
+        + "  <!--\n"
+        + "  STATUS: ok|no_knowledge|need_clarification\n"
+        + "  REASON_CODE: <optional>\n"
+        + "  CITATIONS: chunk_id=1,knowledge_id=2,page_id=3,score=0.42 | chunk_id=...\n"
+        + "  -->\n"
+        + "- When status=ok, the answer must be present and CITATIONS must include at least 1 item.\n"
+        + "- When status=no_knowledge or need_clarification, keep the answer concise and set CITATIONS to empty.\n"
         + "- Ground your answer strictly in the provided context.\n"
         + "- Respond in the same language as the question (Korean/English/Chinese/Japanese).\n"
         + "- Do not switch output language based on the context language; follow the user's question language only.\n"
-        + "- If the context is insufficient, do not end with 'no information'; switch to a clarifying question.\n"
-        + "- If force_clarify is True, output only a clarifying question instead of an answer.\n"
+        + "- If force_clarify is True, set status=need_clarification and answer with a clarifying question.\n"
         + "- Use only the URLs in the [SOURCES] section for download/external links.\n"
     )
 
@@ -307,7 +312,7 @@ def make_qa_chain(
             "[Context Start]\n{context}\n[Context End]\n\n"
             "Question: {question}\n"
             "force_clarify: {force_clarify}\n\n"
-            "Output rules: Markdown OK / code blocks (``` ) forbidden / JSON-only forbidden / answer in the question language (Korean/English/Chinese/Japanese)\n",
+            "Output rules: Markdown only / no code blocks / answer in the question language (Korean/English/Chinese/Japanese)\n",
         )
     )
 

--- a/langchain_service/llm/runner.py
+++ b/langchain_service/llm/runner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 import logging
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -19,7 +20,7 @@ from schemas.llm import QASource, QAResponse
 from core import config
 from core.pricing import tokens_for_texts, estimate_llm_cost_usd
 
-from service.knowledge_retrieval import retrieve_topk_hybrid
+from service.knowledge_retrieval import retrieve_topk_hybrid_with_scores
 
 from langchain_service.chain.qa_chain import make_qa_chain
 from langchain_service.embedding.get_vector import _to_vector
@@ -56,8 +57,8 @@ def _retrieve_sources_and_context(
     knowledge_id: Optional[int],
     top_k: int,
     question: str,
-) -> Tuple[List[QASource], str]:
-    chunks = retrieve_topk_hybrid(
+) -> Tuple[List[QASource], str, dict[str, Any]]:
+    chunks, score_map, max_sim = retrieve_topk_hybrid_with_scores(
         db,
         query_vector=vector,
         knowledge_id=knowledge_id,
@@ -65,19 +66,34 @@ def _retrieve_sources_and_context(
         query_text=question,
     )
 
-    sources: List[QASource] = [
-        QASource(
-            chunk_id=getattr(c, "id", None),
-            knowledge_id=getattr(c, "knowledge_id", None),
-            page_id=getattr(c, "page_id", None),
-            chunk_index=getattr(c, "chunk_index", None),
-            text=getattr(c, "chunk_text", "") or "",
+    sources: List[QASource] = []
+    context_lines: list[str] = []
+    for c in chunks:
+        cid = getattr(c, "id", None)
+        kid = getattr(c, "knowledge_id", None)
+        pid = getattr(c, "page_id", None)
+        score = None
+        if cid is not None and int(cid) in score_map:
+            score = score_map[int(cid)].get("sim")
+        score_repr = f"{float(score):.4f}" if score is not None else "null"
+        context_lines.append(
+            f"[CHUNK id={cid} knowledge_id={kid} page_id={pid} score={score_repr}]"
         )
-        for c in chunks
-    ]
+        chunk_text = getattr(c, "chunk_text", "") or ""
+        context_lines.append(chunk_text)
+        sources.append(
+            QASource(
+                chunk_id=cid,
+                knowledge_id=kid,
+                page_id=pid,
+                chunk_index=getattr(c, "chunk_index", None),
+                text=chunk_text,
+            )
+        )
 
-    context_text = ("\n\n".join(s.text for s in sources))[:MAX_CTX_CHARS]
-    return sources, context_text
+    context_text = ("\n\n".join(context_lines))[:MAX_CTX_CHARS]
+    meta = {"max_sim": max_sim, "has_chunks": bool(chunks)}
+    return sources, context_text, meta
 
 
 def _render_prompt_for_estimate(
@@ -90,11 +106,11 @@ def _render_prompt_for_estimate(
     system_txt = build_system_prompt(style=(style or "friendly"), **(policy_flags or {}))
     return [
         system_txt,
-        "다음 컨텍스트를 참고해.",
-        "[컨텍스트 시작]",
+        "Refer to the following context.",
+        "[Context Start]",
         context_text,
-        "[컨텍스트 끝]",
-        "질문: " + question,
+        "[Context End]",
+        "Question: " + question,
         "force_clarify: False",
     ]
 
@@ -132,13 +148,27 @@ def _run_qa(
             db.refresh(message)
 
     # 검색 1회
-    sources, context_text = _retrieve_sources_and_context(
+    sources, context_text, meta = _retrieve_sources_and_context(
         db,
         vector=vector,
         knowledge_id=knowledge_id,
         top_k=top_k,
         question=question,
     )
+
+    min_score = float(getattr(config, "RAG_MIN_SCORE", 0.12))
+    max_sim = meta.get("max_sim")
+    if not meta.get("has_chunks") or (max_sim is not None and float(max_sim) < min_score):
+        return QAResponse(
+            status="no_knowledge",
+            answer="지식베이스에서 근거를 찾지 못했습니다. 질문을 조금 더 구체적으로 알려주세요.",
+            reason_code="LOW_RETRIEVAL",
+            citations=[],
+            question=question,
+            session_id=session_id,
+            sources=[],
+            documents=[],
+        )
 
     provider = getattr(config, "LLM_PROVIDER", "openai").lower()
     model = getattr(config, "LLM_MODEL", getattr(config, "DEFAULT_CHAT_MODEL", "gpt-4o-mini"))
@@ -254,10 +284,74 @@ def _run_qa(
             detail = f"{detail} ({type(exc).__name__}: {exc})"
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=detail) from exc
 
+    status_val = "no_knowledge"
+    reason_code = "MISSING_METADATA"
+    citations: list[dict[str, Any]] = []
+    answer_val = resp_text or ""
+
+    meta_match = re.search(r"<!--(.*?)-->\s*$", resp_text or "", flags=re.DOTALL)
+    if meta_match:
+        meta_block = meta_match.group(1)
+        answer_val = (resp_text or "")[: meta_match.start()].strip()
+        for raw_line in meta_block.splitlines():
+            line = raw_line.strip()
+            if not line or ":" not in line:
+                continue
+            key, val = [p.strip() for p in line.split(":", 1)]
+            key_upper = key.upper()
+            if key_upper == "STATUS":
+                status_val = val
+            elif key_upper == "REASON_CODE":
+                reason_code = val or None
+            elif key_upper == "CITATIONS":
+                items = [v.strip() for v in val.split("|") if v.strip()]
+                for item in items:
+                    entry: dict[str, Any] = {}
+                    for part in item.split(","):
+                        if "=" not in part:
+                            continue
+                        k, v = [p.strip() for p in part.split("=", 1)]
+                        if k in {"chunk_id", "knowledge_id", "page_id"}:
+                            try:
+                                entry[k] = int(v)
+                            except Exception:
+                                continue
+                        elif k == "score":
+                            try:
+                                entry[k] = float(v)
+                            except Exception:
+                                continue
+                    if entry:
+                        citations.append(entry)
+
+    if status_val not in {"ok", "no_knowledge", "need_clarification"}:
+        status_val = "no_knowledge"
+        reason_code = reason_code or "INVALID_METADATA"
+
+    if status_val == "ok" and not citations:
+        status_val = "no_knowledge"
+        reason_code = reason_code or "MISSING_CITATION"
+
+    if status_val != "ok":
+        if status_val == "need_clarification":
+            answer_val = "질문을 조금 더 구체적으로 알려주세요."
+        else:
+            answer_val = "지식베이스에서 근거를 찾지 못했습니다. 질문을 조금 더 구체적으로 알려주세요."
+
+    source_map = {int(getattr(s, "chunk_id", 0) or 0): s for s in sources}
+    resolved_sources: list[QASource] = []
+    for item in citations:
+        cid = item.get("chunk_id")
+        if isinstance(cid, int) and cid in source_map:
+            resolved_sources.append(source_map[cid])
+
     return QAResponse(
-        answer=resp_text,
+        status=status_val,
+        answer=str(answer_val or ""),
+        reason_code=reason_code,
+        citations=citations,
         question=question,
         session_id=session_id,
-        sources=sources,
-        documents=sources,
+        sources=resolved_sources,
+        documents=resolved_sources,
     )

--- a/schemas/llm.py
+++ b/schemas/llm.py
@@ -66,6 +66,13 @@ class QASource(BaseModel):
     text: str = Field(default="")
 
 
+class QACitation(BaseModel):
+    knowledge_id: Optional[int] = None
+    chunk_id: Optional[int] = None
+    page_id: Optional[int] = None
+    score: Optional[float] = None
+
+
 class QAResponse(BaseModel):
     """
     QA 응답 표준.
@@ -77,6 +84,10 @@ class QAResponse(BaseModel):
     question: str
     answer: str
     session_id: Optional[int] = None
+
+    status: Literal["ok", "no_knowledge", "need_clarification"] = "ok"
+    reason_code: Optional[str] = None
+    citations: List[QACitation] = Field(default_factory=list)
 
     sources: List[QASource] = Field(default_factory=list)
     documents: List[QASource] = Field(default_factory=list)

--- a/service/chat_history.py
+++ b/service/chat_history.py
@@ -211,6 +211,13 @@ def _load_quick_category_name_map(db: Session) -> Dict[str, int]:
     return out
 
 
+def _get_etc_quick_category_id(name_map: Dict[str, int]) -> Optional[int]:
+    for key in ("etc", "기타"):
+        if key in name_map:
+            return int(name_map[key])
+    return None
+
+
 # =========================
 # Build / rebuild
 # =========================
@@ -241,7 +248,7 @@ def rebuild_range(db: Session, *, date_from: date, date_to: date) -> Dict[str, A
 
     # quick_category name->id 맵 + etc_id
     qc_name_map = _load_quick_category_name_map(db)
-    etc_id: Optional[int] = qc_name_map.get("etc")
+    etc_id = _get_etc_quick_category_id(qc_name_map)
 
     # 1) session_insight 업데이트
     updated_sessions = 0


### PR DESCRIPTION
### Motivation
- Ensure prompt/system text injected into the QA LLM is English-only to satisfy the policy that prompts must be in English.
- Make the assistant output both human-readable Markdown and structured metadata by using an appended HTML comment block so downstream code can reliably parse status and citations.
- Improve retrieval gating by surfacing per-chunk similarity scores and deterministically returning `no_knowledge` when retrieval confidence is low.

### Description
- Replaced Korean prompt text in `langchain_service/llm/runner.py` with English equivalents in `_render_prompt_for_estimate` and related prompt parts to keep injected prompts English-only.
- Updated `langchain_service/chain/qa_chain.py` to instruct the model to append a trailing HTML comment block containing `STATUS`, `REASON_CODE`, and `CITATIONS` metadata and tightened output rules to Markdown-only without code fences.
- Implemented metadata parsing in `langchain_service/llm/runner.py` by extracting a trailing `<!-- ... -->` block with `re`, stripping it from the user-visible answer, validating `STATUS`/`REASON_CODE`/`CITATIONS`, resolving citations into `QASource` objects, and returning a populated `QAResponse` (`status`, `reason_code`, `citations`, `sources`, `documents`).
- Added retrieval scoring support: introduced `retrieve_topk_hybrid_with_scores` in `service/knowledge_retrieval.py` that returns chunk list, a `score_map`, and `max_sim`; updated `_retrieve_sources_and_context` to include per-chunk score annotations in the context and to return `meta` including `max_sim`/`has_chunks`.
- Added `RAG_MIN_SCORE` config in `core/config.py` and applied deterministic gating in `_run_qa` to return `no_knowledge` with `reason_code="LOW_RETRIEVAL"` when `max_sim` is below threshold or no chunks found.
- Extended schemas in `schemas/llm.py` with `QACitation` and added `status`, `reason_code`, and `citations` to `QAResponse` while keeping legacy `sources`/`documents` behavior.
- Adjusted `service/llm_service.py` and `service/chat_history.py` to normalize `channel`, store `status`/`reason_code`/`citations` in message `extra_data`, and mark session insights as `failed` when `resp.status` is not `ok`.

### Testing
- No automated tests were executed for these changes (none were requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696deb3f00848324939786d491d26173)