### PR TITLE
Require QA metadata before marking responses ok

### DIFF
--- a/langchain_service/llm/runner.py
+++ b/langchain_service/llm/runner.py
@@ -326,18 +326,6 @@ def _run_qa(
                     if entry:
                         citations.append(entry)
 
-    if not has_metadata and sources:
-        status_val = "ok"
-        reason_code = reason_code or "MISSING_METADATA"
-        citations = [
-            {
-                "chunk_id": getattr(sources[0], "chunk_id", None),
-                "knowledge_id": getattr(sources[0], "knowledge_id", None),
-                "page_id": getattr(sources[0], "page_id", None),
-                "score": None,
-            }
-        ]
-
     if status_val not in {"ok", "no_knowledge", "need_clarification"}:
         status_val = "no_knowledge"
         reason_code = reason_code or "INVALID_METADATA"


### PR DESCRIPTION
### Motivation
- Prevent LLM answers without explicit `STATUS`/`CITATIONS` metadata from being treated as `ok`, avoiding false-positive QA success states.

### Description
- Remove the fallback in `langchain_service/llm/runner.py` that set `status_val = "ok"` when `has_metadata` was false but `sources` existed, so responses without metadata remain `no_knowledge` unless explicit metadata is provided.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eedce3f1c8324a2235549da47e359)